### PR TITLE
Consistent parameter naming

### DIFF
--- a/test/Spf.t.sol
+++ b/test/Spf.t.sol
@@ -31,9 +31,9 @@ contract SpfTest is Test {
     function test_RequestSpf_EmitsEvent() public {
         // Prepare test data
         Spf.SpfParameter[] memory inputs = new Spf.SpfParameter[](3);
-        inputs[0] = Spf.createCiphertextParam(CIPHERTEXT_ID_1);
-        inputs[1] = Spf.createCiphertextParam(CIPHERTEXT_ID_2);
-        inputs[2] = Spf.createOutputCiphertextArrayParam(4);
+        inputs[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
+        inputs[1] = Spf.createCiphertextParameter(CIPHERTEXT_ID_2);
+        inputs[2] = Spf.createOutputCiphertextArrayParameter(4);
 
         // Calculate expected parameters
         Spf.SpfParameter[] memory expectedParams = new Spf.SpfParameter[](3);
@@ -75,7 +75,7 @@ contract SpfTest is Test {
     function test_RequestSpf_RequireOutputs() public {
         // Prepare test data
         Spf.SpfParameter[] memory inputs = new Spf.SpfParameter[](1);
-        inputs[0] = Spf.createCiphertextParam(CIPHERTEXT_ID_1);
+        inputs[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
 
         // Expect revert with specific message
         vm.expectRevert("SPF: No outputs requested");
@@ -95,11 +95,11 @@ contract SpfTest is Test {
         values[2] = 4;
 
         Spf.SpfParameter[] memory inputs = new Spf.SpfParameter[](5);
-        inputs[0] = Spf.createCiphertextParam(CIPHERTEXT_ID_1);
-        inputs[1] = Spf.createCiphertextArrayParam(identifiers);
-        inputs[2] = Spf.createOutputCiphertextArrayParam(4);
-        inputs[3] = Spf.createPlaintextParam(32, 1);
-        inputs[4] = Spf.createPlaintextArrayParam(32, values);
+        inputs[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
+        inputs[1] = Spf.createCiphertextArrayParameter(identifiers);
+        inputs[2] = Spf.createOutputCiphertextArrayParameter(4);
+        inputs[3] = Spf.createPlaintextParameter(32, 1);
+        inputs[4] = Spf.createPlaintextArrayParameter(32, values);
 
         // Calculate expected parameters
         Spf.SpfParameter[] memory expectedParams = new Spf.SpfParameter[](5);
@@ -178,11 +178,11 @@ contract SpfTest is Test {
     function test_outputHash() public pure {
         // create sample input parameters
         Spf.SpfParameter[] memory parameters = new Spf.SpfParameter[](5);
-        parameters[0] = Spf.createCiphertextParam(CIPHERTEXT_ID_1);
-        parameters[1] = Spf.createCiphertextParam(CIPHERTEXT_ID_2);
-        parameters[2] = Spf.createCiphertextParam(CIPHERTEXT_ID_3);
-        parameters[3] = Spf.createCiphertextParam(CIPHERTEXT_ID_4);
-        parameters[4] = Spf.createOutputCiphertextArrayParam(4);
+        parameters[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
+        parameters[1] = Spf.createCiphertextParameter(CIPHERTEXT_ID_2);
+        parameters[2] = Spf.createCiphertextParameter(CIPHERTEXT_ID_3);
+        parameters[3] = Spf.createCiphertextParameter(CIPHERTEXT_ID_4);
+        parameters[4] = Spf.createOutputCiphertextArrayParameter(4);
 
         // create SpfRun struct
         Spf.SpfRun memory run = Spf.SpfRun({spfLibrary: SPF_LIBRARY, program: SPF_PROGRAM, parameters: parameters});
@@ -220,15 +220,15 @@ contract SpfTest is Test {
     function test_outputHashDifferentInputsDifferentHashes() public pure {
         // create first SpfRun struct
         Spf.SpfParameter[] memory params1 = new Spf.SpfParameter[](2);
-        params1[0] = Spf.createCiphertextParam(CIPHERTEXT_ID_1);
-        params1[1] = Spf.createOutputCiphertextArrayParam(4);
+        params1[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
+        params1[1] = Spf.createOutputCiphertextArrayParameter(4);
 
         Spf.SpfRun memory run1 = Spf.SpfRun({spfLibrary: SPF_LIBRARY, program: SPF_PROGRAM, parameters: params1});
 
         // create second SpfRun struct with slightly different parameters
         Spf.SpfParameter[] memory params2 = new Spf.SpfParameter[](2);
-        params2[0] = Spf.createCiphertextParam(CIPHERTEXT_ID_2); // Different value
-        params2[1] = Spf.createOutputCiphertextArrayParam(4);
+        params2[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_2); // Different value
+        params2[1] = Spf.createOutputCiphertextArrayParameter(4);
 
         Spf.SpfRun memory run2 = Spf.SpfRun({spfLibrary: SPF_LIBRARY, program: SPF_PROGRAM, parameters: params2});
 

--- a/test/TfheThresholdDecryption.t.sol
+++ b/test/TfheThresholdDecryption.t.sol
@@ -5,23 +5,6 @@ import "forge-std/Test.sol";
 import "../contracts/TfheThresholdDecryption.sol";
 import "../contracts/Spf.sol";
 
-// Create a test contract that exposes the Spf library functions
-contract SpfWrapper {
-    using Spf for *;
-
-    function exposedCreateCiphertextParam(Spf.SpfCiphertextIdentifier identifier)
-        external
-        pure
-        returns (Spf.SpfParameter memory)
-    {
-        return Spf.createCiphertextParam(identifier);
-    }
-
-    function exposedCreateOutputCiphertextArrayParam(uint8 numBytes) external pure returns (Spf.SpfParameter memory) {
-        return Spf.createOutputCiphertextArrayParam(numBytes);
-    }
-}
-
 // Mock contract that inherits from TfheThresholdDecryption
 contract MockDecryptionUser is TfheThresholdDecryption {
     using Spf for *;
@@ -81,8 +64,6 @@ contract TfheThresholdDecryptionTest is Test {
     Spf.SpfCiphertextIdentifier constant CIPHERTEXT_ID_2 =
         Spf.SpfCiphertextIdentifier.wrap(0x13ca007bae631cf35724b1d4c92ac26cd8fa49c2e1b30cc7b886f86d8a579525);
 
-    SpfWrapper public spfWrapper;
-
     // Test contract instances
     MockDecryptionUser public mockUser;
 
@@ -97,8 +78,6 @@ contract TfheThresholdDecryptionTest is Test {
     event RunProgramOnSpf(address indexed sender, Spf.SpfRun run);
 
     function setUp() public {
-        spfWrapper = new SpfWrapper();
-
         // Deploy the mock user contract
         mockUser = new MockDecryptionUser(SPF_LIBRARY, PROGRAM);
     }
@@ -106,12 +85,12 @@ contract TfheThresholdDecryptionTest is Test {
     function test_ExecuteAndRequestDecryption() public {
         // Create test input parameters
         Spf.SpfParameter[] memory inputs = new Spf.SpfParameter[](3);
-        inputs[0] = spfWrapper.exposedCreateCiphertextParam(CIPHERTEXT_ID_1);
-        inputs[1] = spfWrapper.exposedCreateCiphertextParam(CIPHERTEXT_ID_2);
-        inputs[2] = spfWrapper.exposedCreateOutputCiphertextArrayParam(4);
+        inputs[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
+        inputs[1] = Spf.createCiphertextParameter(CIPHERTEXT_ID_2);
+        inputs[2] = Spf.createOutputCiphertextArrayParameter(4);
 
         // Expect RunProgramOnSpf event
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, true, true, true);
 
         // Calculate expected parameters
         Spf.SpfParameter[] memory expectedParams = new Spf.SpfParameter[](3);
@@ -175,8 +154,8 @@ contract TfheThresholdDecryptionTest is Test {
     function test_MultipleOutputs() public {
         // Create test input parameters
         Spf.SpfParameter[] memory inputs = new Spf.SpfParameter[](2);
-        inputs[0] = spfWrapper.exposedCreateCiphertextParam(CIPHERTEXT_ID_1);
-        inputs[1] = spfWrapper.exposedCreateOutputCiphertextArrayParam(12);
+        inputs[0] = Spf.createCiphertextParameter(CIPHERTEXT_ID_1);
+        inputs[1] = Spf.createOutputCiphertextArrayParameter(12);
 
         // Execute the function
         Spf.SpfRunHandle runHandle = mockUser.executeAndRequestDecryption(inputs);


### PR DESCRIPTION
The parameter naming was inconsistent (in some places param, in some places parameter). This makes it consistent.

Additionally removed the wrapper in the ThresholdTFHE contract, and made functions to return SpfParameters for trivial values.